### PR TITLE
Revert to manifest v2

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -16,5 +16,5 @@
     "persistent": false
   },
   "options_page": "options.html",
-  "manifest_version": 3
+  "manifest_version": 2
 }


### PR DESCRIPTION
> The "background.scripts" key cannot be used with manifest_version
> 3. Use the "background.service_worker" key instead.  Could not load
> manifest.

I'll need to convert this over before bumping to v3.