### PR TITLE
Add project names in task results for Alfred

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/apiology/opener-for-asana#readme",
   "_devDependenciesNotes": "copy-webpack-plugin 10 failed with this - https://stackoverflow.com/questions/70080671/copy-webpack-plugin-error-invalid-host-defined-options",
   "devDependencies": {
-    "@types/asana": "^0.18.5",
+    "@types/asana": "^0.18.7",
     "@types/chrome": "^0.0.163",
     "@types/jest": "^28.1.2",
     "@types/lodash": "^4.14.176",
@@ -62,11 +62,11 @@
     "alfy": "^1.0.0",
     "asana": "^0.18.5",
     "buffer": "^6.0.3",
+    "lodash": "^4.17.21",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "url": "^0.11.0",
-    "util": "^0.12.4",
-    "lodash": "^4.17.21"
+    "util": "^0.12.4"
   },
   "_resolutionsComments": "asana requires request ^2.88.2 (which is deprecated and not receiving updates), which requires http-signature ~1.2.0, which requires jsprim ^1.2.2, which requires json-schema@0.2.3, which is perhaps vulnerable to CVE-2021-3918 (moderate)",
   "resolutions": {

--- a/src/asana-typeahead.ts
+++ b/src/asana-typeahead.ts
@@ -9,19 +9,19 @@ import * as Asana from 'asana';
 import { platform } from './platform.js';
 import { fetchClient, fetchWorkspaceGid } from './asana-base.js';
 
-export async function pullResult(text: string, resourceType: 'task', optFields: string[]):
+export async function pullResult(text: string, resourceType: 'task', optFields: string):
   Promise<Asana.resources.ResourceList<Asana.resources.Tasks.Type>>;
-export async function pullResult(text: string, resourceType: 'project', optFields: string[]):
+export async function pullResult(text: string, resourceType: 'project', optFields: string):
   Promise<Asana.resources.ResourceList<Asana.resources.Projects.Type>>;
-export async function pullResult(text: string, resourceType: 'custom_field', optFields: string[]):
+export async function pullResult(text: string, resourceType: 'custom_field', optFields: string):
   Promise<Asana.resources.ResourceList<Asana.resources.CustomFields.Type>>;
-export async function pullResult(text: string, resourceType: 'project', optFields: string[]):
+export async function pullResult(text: string, resourceType: 'project', optFields: string):
   Promise<Asana.resources.ResourceList<Asana.resources.Projects.Type>>;
-// export async function pullResult(text: string, resourceType: 'portfolio', optFields: string[]):
+// export async function pullResult(text: string, resourceType: 'portfolio', optFields: string):
 //  Promise<Asana.resources.ResourceList<Asana.resources.Portfolios.Type>>;
-export async function pullResult(text: string, resourceType: 'tag', optFields: string[]):
+export async function pullResult(text: string, resourceType: 'tag', optFields: string):
   Promise<Asana.resources.ResourceList<Asana.resources.Tags.Type>>;
-export async function pullResult(text: string, resourceType: string, optFields: string[]):
+export async function pullResult(text: string, resourceType: string, optFields: string):
   Promise<Asana.resources.ResourceList<Asana.resources.Resource>> {
   const query: Asana.resources.Typeahead.TypeaheadParams = {
     resource_type: resourceType,

--- a/src/opener-for-asana.ts
+++ b/src/opener-for-asana.ts
@@ -21,7 +21,7 @@ export type Suggestion = {
 
 export const pullSuggestions = async (text: string): Promise<Suggestion[]> => {
   const formatter = platform().formatter();
-  return (await pullResult(text, 'task', ['name', 'completed', 'parent.name', 'custom_fields.gid', 'custom_fields.number_value', 'memberships.project.name'])).data.map((task) => {
+  return (await pullResult(text, 'task', 'name,completed,parent.name,custom_fields.gid,custom_fields.number_value,memberships.project.name')).data.map((task) => {
     const description = formatter.formatTask(task);
     const url = `opener-for-asana:${task.gid}`;
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,10 +634,10 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
-"@types/asana@^0.18.5":
-  version "0.18.5"
-  resolved "https://registry.yarnpkg.com/@types/asana/-/asana-0.18.5.tgz#27b011042a2e4ead6d17f9913bc26b67a73956a1"
-  integrity sha512-z+oqx98trMPdEOkb4XPLiMBPRUmE1Y0tObeHIj7a8I/+BQMDuIrOFX5J5yyLlL9DtrDCJgtXyoKwVTJeaWP95g==
+"@types/asana@^0.18.7":
+  version "0.18.7"
+  resolved "https://registry.yarnpkg.com/@types/asana/-/asana-0.18.7.tgz#22d16cd7f5bcaa60f2d62ee7405817f1372b29a2"
+  integrity sha512-OhGx4BXExeGBHDIP/CjNx4UxJ4g+t2tMDVRG7LYxjDUZr+FYm2dKtbH4DK9qnkvE9Uu9Gs2YzAot+yh2DNR8+w==
   dependencies:
     "@types/bluebird" "*"
 


### PR DESCRIPTION
This imports the fix to types in
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60776 which
avoids the incorrect HTTP client behavior when run under Node that was
resulting in project names not appearing in task results when run for
Alfred.